### PR TITLE
Fix logfile links with spaces or UTF-8 chars (#10)

### DIFF
--- a/poc/main_window.cpp
+++ b/poc/main_window.cpp
@@ -648,6 +648,10 @@ void TeraMainWin::showLog(QUrl const& link) {
     if (!success) {
         success = QProcess::startDetached("open", QStringList()  << link.url());
     }
+#elif defined(Q_OS_WIN)
+    if (!success) {
+        success = QDesktopServices::openUrl(QUrl("file:///" + link.url(), QUrl::TolerantMode));
+    }
 #endif
 
     if (!success) {


### PR DESCRIPTION
TERA-222
Open the log file of the timestamping process correctly in Windows 10
if it contains spaces or UTF-8 characters.
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>