### PR TITLE
TERA-276: Use OpenSC for Idemia cards instead of AWP drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,6 @@ find_package(Qt5 COMPONENTS Core Widgets Network LinguistTools REQUIRED)
 find_package(PKCS11)
 find_package(OpenSSL REQUIRED)
 find_package(ZLIB REQUIRED)
-find_library( AWP_MODULE NAMES libOcsCryptoki.dylib PATHS /Library/AWP/lib /usr/local/AWP/lib )
 include_directories(${OPENSSL_INCLUDE_DIR} ${ZIP_INCLUDE_DIR})
 
 message(STATUS "Qt5Core version:     " ${Qt5Core_VERSION})
@@ -237,14 +236,6 @@ elseif( APPLE )
         COMMAND ${_qt5Core_install_prefix}/bin/macdeployqt ${CMAKE_CURRENT_BINARY_DIR}/${TERA_GUI_NAME}.app
             -executable=${CMAKE_CURRENT_BINARY_DIR}/${PROGNAME}.app/Contents/MacOS/${PKCS11_NAME}
     )
-    if(AWP_MODULE)
-        get_filename_component(AWP_PATH ${AWP_MODULE} PATH)
-        get_filename_component(AWP_PATH ${AWP_PATH} PATH)
-        add_custom_command(TARGET macdeployqt POST_BUILD
-            COMMAND cp -a ${AWP_PATH}/lib/* $<TARGET_FILE_DIR:${PROGNAME}>
-            COMMAND cp -a ${AWP_PATH}/*.xml $<TARGET_FILE_DIR:${PROGNAME}>/../Resources
-        )
-    endif()
     add_custom_target( codesign DEPENDS ${TERA_GUI_NAME}
         COMMAND codesign -f -s \"$$SIGNCERT\"
             $<TARGET_FILE_DIR:${PROGNAME}>/*.*

--- a/common/QPKCS11.cpp
+++ b/common/QPKCS11.cpp
@@ -356,7 +356,6 @@ bool QPKCS11::reload()
 		{ "/Library/OpenSC/lib/opensc-pkcs11.so", "3B7B940000806212515646696E454944" },
 		{ "/Library/Frameworks/eToken.framework/Versions/Current/libeToken.dylib", "3BD5180081313A7D8073C8211030" },
 		{ "/Library/Frameworks/eToken.framework/Versions/Current/libeToken.dylib", "3BD518008131FE7D8073C82110F4" },
-		{ qApp->applicationDirPath() + "/libOcsCryptoki.dylib", "3BDB960080B1FE451F830012233F536549440F9000F1" }
 #elif defined(Q_OS_WIN)
 		{ "OTLvP11.dll", "3BDD18008131FE45904C41545649412D65494490008C" },
 		{ qApp->applicationDirPath() + "/../CryptoTech/CryptoCard/CCPkiP11.dll", "3BF81300008131FE45536D617274417070F8" },
@@ -367,7 +366,6 @@ bool QPKCS11::reload()
 		{ "/usr/lib/ccs/libccpkip11.so", "3BF81300008131FE45536D617274417070F8" },
 		{ "/usr/lib/ccs/libccpkip11.so", "3B7D94000080318065B08311C0A983009000" },
 		{ "libcryptoki.so", "3B7F9600008031B865B0850300EF1200F6829000" },
-		{ "/usr/local/AWP/lib/libOcsCryptoki.so", "3BDB960080B1FE451F830012233F536549440F9000F1" }
 #endif
 	};
 #ifdef Q_OS_MAC

--- a/debian/control
+++ b/debian/control
@@ -20,8 +20,6 @@ Depends:
  pcscd (>=1.5),
  ${misc:Depends},
  ${shlibs:Depends}
-Recommends:
- awp
 Description: Estonian DDOC re-timestamping utility
  TeRa is a part of Estonian national ID-card software developed by
  CGI on behalf of governmental institution - Estonian


### PR DESCRIPTION
- remove loading of AWP drivers for macOS and Linux;
- do not copy of AWP drivers to macOS package